### PR TITLE
feat(elon-883): create custom eslint config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# project
+index.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "eslint-config-ssense",
+  "version": "0.0.0",
+  "description": "JavaScript code standards at SSENSE",
+  "main": "index.js",
+  "scripts": {
+    "build": "echo 'module.exports = ' > index.js && js-yaml source/base.yaml >> index.js",
+    "prepublish": "npm run build",
+    "postversion": "git push && git push --tags && npm publish"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SSENSE/eslint-config.git"
+  },
+  "keywords": [
+    "eslint",
+    "eslintconfig"
+  ],
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/SSENSE/eslint-config/issues"
+  },
+  "homepage": "https://github.com/SSENSE/eslint-config#readme",
+  "dependencies": {},
+  "devDependencies": {
+    "js-yaml": "^3.4.2"
+  },
+  "peerDependencies": {
+    "eslint": ">= 3",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-fp": "^2.2.0",
+    "babel-eslint": "^7.1.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,14 +22,17 @@
     "url": "https://github.com/SSENSE/eslint-config/issues"
   },
   "homepage": "https://github.com/SSENSE/eslint-config#readme",
-  "dependencies": {},
+  "dependencies": {
+  },
   "devDependencies": {
     "js-yaml": "^3.4.2"
   },
   "peerDependencies": {
+    "babel-eslint": "^7.1.1",
     "eslint": ">= 3",
+    "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-fp": "^2.2.0",
-    "babel-eslint": "^7.1.1"
+    "eslint-plugin-vue": "^1.0.0"
   }
 }

--- a/source/base.yaml
+++ b/source/base.yaml
@@ -1,0 +1,57 @@
+extends:
+  - airbnb-base
+parser: babel-eslint
+parserOptions:
+  ecmaVersion: 2017
+  sourceType: module
+  ecmaFeatures:
+    impliedStrict: true
+    experimentalObjectRestSpread: true
+plugins:
+  - import
+  - fp
+env:
+  browser: true
+  mocha: true
+rules:
+
+  semi: [1, never]
+  quotes: [1, double]
+  comma-dangle: [1, only-multiline]
+  no-multiple-empty-lines: [1, { max: 3 }]
+
+  import/no-namespace: 1
+  import/no-commonjs: 1
+  import/order:
+    - 1
+    - groups: [builtin, external, internal, parent, sibling, index]
+      newlines-between: never
+
+  fp/no-arguments: 2
+  fp/no-class: 2
+  fp/no-delete: 2
+  fp/no-events: 2
+  fp/no-get-set: 2
+  fp/no-let: 2
+  fp/no-loops: 2
+  fp/no-this: 2
+
+  # Consider
+
+  # fp/no-mutating-assign: 2
+  # fp/no-mutating-methods: 2
+  # fp/no-mutation: 2
+  # fp/no-nil: 2
+  # fp/no-rest-parameters: 2
+  # fp/no-throw: 2
+  # https://github.com/jfmengels/eslint-plugin-lodash-fp
+  # https://github.com/xjamundx/eslint-plugin-promise
+  # https://github.com/johnstonbl01/eslint-no-inferred-method-name
+  # https://github.com/selaux/eslint-plugin-filenames
+  # https://github.com/gajus/eslint-plugin-jsdoc
+
+  # Disable
+
+  space-before-function-paren: 0
+  operator-linebreak: 0
+  object-curly-spacing: 0

--- a/source/base.yaml
+++ b/source/base.yaml
@@ -1,31 +1,48 @@
 extends:
   - airbnb-base
+
 parser: babel-eslint
+
 parserOptions:
   ecmaVersion: 2017
   sourceType: module
   ecmaFeatures:
     impliedStrict: true
     experimentalObjectRestSpread: true
+
 plugins:
   - import
   - fp
+  - vue
+
 env:
   browser: true
   mocha: true
+
 rules:
+
+  # Misc
 
   semi: [1, never]
   quotes: [1, double]
   comma-dangle: [1, only-multiline]
   no-multiple-empty-lines: [1, { max: 3 }]
 
+  # Import
+
   import/no-namespace: 1
   import/no-commonjs: 1
+  import/no-extraneous-dependencies:
+    - 2
+    - devDependencies:
+      - "**/*.test.js"
+      - "**/*.spec.js"
   import/order:
     - 1
     - groups: [builtin, external, internal, parent, sibling, index]
       newlines-between: never
+
+  # Functional Programming
 
   fp/no-arguments: 2
   fp/no-class: 2
@@ -35,6 +52,13 @@ rules:
   fp/no-let: 2
   fp/no-loops: 2
   fp/no-this: 2
+
+  # Disable
+
+  space-before-function-paren: 0
+  operator-linebreak: 0
+  object-curly-spacing: 0
+  no-nested-ternary: 0
 
   # Consider
 
@@ -49,9 +73,3 @@ rules:
   # https://github.com/johnstonbl01/eslint-no-inferred-method-name
   # https://github.com/selaux/eslint-plugin-filenames
   # https://github.com/gajus/eslint-plugin-jsdoc
-
-  # Disable
-
-  space-before-function-paren: 0
-  operator-linebreak: 0
-  object-curly-spacing: 0


### PR DESCRIPTION
##### Highlights

* Introduce some bite-size bits of FP officially
* Make module syntax official
* Forbid so-called "namespace importing"
* Extend AirBnB
* no semi-colons
* double quotes
* `vue` plugin allows `.vue` files to be linted. Very sadly it does not support `--fix` ?!!?
* `Disable` section is mostly based on what I saw in [`ui-website`](https://github.com/Groupe-Atallah/ui-website/blob/master/.eslintrc)

##### TODO

- [x] Update readme with note about user needing to install all the peer-deps manually. We can avoid this once https://github.com/eslint/eslint/issues/3458 is resolved (maybe soon?!)
- [ ] Update readme with example of overriding locally for e.g. `let`
- [x] Update readme with example of usage
- [ ] Update readme with summary explanation
- [x] Allow seniors time to review
- [x] Add Todd and Johann as reviewers once they are members of @ssense org

##### Caveats

* Vue projects will probably need the global override `fp/no-this: 0` because its heavy reliance on `this`. If Vue has pure components like React then my advice might adjust to suggesting only module-overrides.